### PR TITLE
TOWER-9499 update maxCount logic & add onClose to componentWillUnmount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,5 @@ package-lock.json
 .umi
 .umi-production
 .umi-test
-.env.local 
+.env.local
+.doc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rc-notification",
-  "version": "4.6.0",
+  "name": "@cloudtower/rc-notification",
+  "version": "4.6.1",
   "description": "notification ui component for react",
   "engines": {
     "node": ">=8.x"

--- a/src/Notification.tsx
+++ b/src/Notification.tsx
@@ -105,30 +105,19 @@ class Notification extends Component<NotificationProps, NotificationState> {
     this.setState((previousState: NotificationState) => {
       const { notices } = previousState;
       const noticeIndex = notices.map((v) => v.notice.key).indexOf(key);
-      const updatedNotices = notices.concat();
+      let updatedNotices = notices.concat();
       if (noticeIndex !== -1) {
         updatedNotices.splice(noticeIndex, 1, { notice, holderCallback });
       } else {
-        if (maxCount && notices.length >= maxCount) {
-          // XXX, use key of first item to update new added (let React to move exsiting
-          // instead of remove and mount). Same key was used before for both a) external
-          // manual control and b) internal react 'key' prop , which is not that good.
-          // eslint-disable-next-line no-param-reassign
-
-          // zombieJ: Not know why use `updateKey`. This makes Notice infinite loop in jest.
-          // Change to `updateMark` for compare instead.
-          // https://github.com/react-component/notification/commit/32299e6be396f94040bfa82517eea940db947ece
-          notice.key = updatedNotices[0].notice.key as React.Key;
-          notice.updateMark = getUuid();
-
-          // zombieJ: That's why. User may close by key directly.
-          // We need record this but not re-render to avoid upper issue
-          // https://github.com/react-component/notification/issues/129
-          notice.userPassKey = key;
-
-          updatedNotices.shift();
-        }
+        /**
+         * [关联文件](https://github.com/react-component/notification/blob/3af048163422bb03f044e24f5d47e68e8953ca74/src/Notifications.tsx#L77)
+         * [关联 commit](https://github.com/react-component/notification/commit/2a2dd67c1cf8897700b247a4954bc0ac0ee8178d)
+         */
         updatedNotices.push({ notice, holderCallback });
+
+        if (maxCount && notices.length >= maxCount) {
+          updatedNotices = updatedNotices.slice(-maxCount);
+        }
       }
       return {
         notices: updatedNotices,


### PR DESCRIPTION
- 更新了 maxCount 的逻辑。新增 notification 时，把超过 maxCount 的部分删除（从视图的上方开始删除）。
- 更新了 componentWillUnmount 的逻辑，由于 batchMessage 依赖了 onClose ，但是默认只有定时器关闭可以触发 onClose，所以增加组件关闭时，也触发 onClose。如果没有 onClose batchMessage 内部状态会一直处于 batch，导致后续不在 batch 条件内的消息以 batch 形式发出。

结合 batchMessage 自测效果

包含随机 key 的message 是在 batchMessage 时间内，连续点击超过 2 次后产生。

如果点击后，超过 batchMessage 时间。则显示 普通消息 + count

![Jul-31-2023 13-29-52](https://github.com/webzard-io/notification/assets/17702287/9954214a-5134-4712-823d-7026d5828657)

@netweng @Kun8018 PTAL